### PR TITLE
feat: WSL2/Linux (Ubuntu 22.04) 対応

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## プロジェクト概要
+
+DN_SuperBook_PDF_Converter は、スキャンした書籍 PDF を高品質化・調整するツール。紙の汚れ、裏写り、インクにじみ、JPEG モアレノイズの除去、傾き補正、ページ番号自動検出・PDF メタデータ設定などを行う。
+
+## ビルド・実行コマンド
+
+```bash
+# ビルド (Visual Studio 2022/2026)
+# DN_SuperBook_PDF_Converter_VS2026.sln を開いてビルド
+
+# CLI からビルド (dotnet)
+dotnet build SuperBookToolsApp/SuperBookToolsApp.csproj
+
+# 実行（デバッグなしで実行を推奨。デバッグありだと重くなる）
+dotnet run --project SuperBookToolsApp/SuperBookToolsApp.csproj
+
+# PDF 変換コマンド（プログラム起動後のプロンプトで）
+ConvertPdf <srcDir> /dst:<dstDir>
+
+# ヘルプ
+ConvertPdf --help
+```
+
+## アーキテクチャ
+
+### プロジェクト構成
+- **SuperBookToolsApp/** - メインアプリケーション (エントリーポイント、CLI コマンド)
+  - `Startup.cs` - Main 関数、ConsoleService によるコマンドループ
+  - `AiCommands.cs` - `ConvertPdf` コマンド実装、外部ツールパス設定
+- **SuperBookTools/** - 共有ライブラリ (Shared Project)
+  - `Basic/SuperPdfUtil.cs` - PDF 処理のコアロジック (約3000行)
+- **submodules/IPA-DN-Cores/** - 共通ライブラリ (Cores.NET)
+
+### 主要クラス
+- `SuperPdfUtil` - PDF 変換メイン処理 (`PerformPdfAsync`)
+- `PnOcrLib` - ページ番号 OCR 検出・書籍メタデータ処理
+- `SuperImgUtil` - 画像処理ユーティリティ
+- `DnImageSharpHelper` - ImageSharp 拡張メソッド
+
+### 外部ツール依存
+`external_tools/external_tools/image_tools/` に配置が必要:
+- ImageMagick + Ghostscript
+- exiftool
+- qpdf
+- pdfcpu
+- RealEsrgan (Python/CUDA 環境)
+- Tesseract OCR データ
+
+### NuGet パッケージ
+- OpenCvSharp4 - 画像処理
+- SixLabors.ImageSharp.Drawing - 画像描画
+- Tesseract - OCR エンジン
+
+## 技術スタック
+- C# / .NET 6.0
+- IPA-DN-Cores ライブラリ（ファイル操作、コンソールサービス等）
+- RealEsrgan (AI 画像鮮明化、Python + CUDA)
+- Tesseract OCR (ページ番号検出用)
+
+## 開発メモ
+- メモリ使用量が大きい（数GB〜数十GB の可能性）
+- GPU (NVIDIA CUDA 対応) が必要（RealEsrgan 処理）
+- Windows 向けに開発されているが、C# なので原理的に Linux/macOS 対応可能

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,240 @@
+# DN_SuperBook_PDF_Converter インストールガイド (WSL2/Linux)
+
+このドキュメントは WSL2 Ubuntu 22.04 環境でのセットアップ手順を説明します。
+
+## 前提条件
+
+- Ubuntu 22.04 (WSL2)
+- NVIDIA GPU (CUDA 対応、RTX 3090 等)
+- NVIDIA ドライバがインストール済み
+
+## 1. .NET 8 SDK のインストール
+
+```bash
+# Microsoft パッケージリポジトリを追加
+wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+rm packages-microsoft-prod.deb
+
+# .NET 8 SDK をインストール
+sudo apt-get update
+sudo apt-get install -y dotnet-sdk-8.0
+
+# 確認
+dotnet --version
+```
+
+## 2. システムパッケージのインストール
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+    imagemagick \
+    ghostscript \
+    libimage-exiftool-perl \
+    qpdf \
+    python3 \
+    python3-pip \
+    python3-venv \
+    libtesseract-dev \
+    tesseract-ocr \
+    tesseract-ocr-jpn \
+    tesseract-ocr-jpn-vert \
+    wget \
+    curl \
+    unzip \
+    libgtk2.0-0
+```
+
+**注意**: `libgtk2.0-0` は OpenCvSharp のネイティブライブラリが依存しています。
+
+## 3. ImageMagick 設定
+
+### PDF ポリシー解除
+
+ImageMagick はデフォルトで PDF の読み書きが制限されているため、解除が必要です。
+
+```bash
+sudo sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' /etc/ImageMagick-6/policy.xml
+```
+
+### メモリ/ディスク制限の緩和
+
+大きな PDF (数十ページ以上) を処理する場合、デフォルトのリソース制限では不足します。
+
+```bash
+# メモリ制限を 256MB → 4GB に拡大
+sudo sed -i 's/name="memory" value="256MiB"/name="memory" value="4GiB"/' /etc/ImageMagick-6/policy.xml
+
+# ディスク制限を 1GB → 16GB に拡大
+sudo sed -i 's/name="disk" value="1GiB"/name="disk" value="16GiB"/' /etc/ImageMagick-6/policy.xml
+```
+
+## 4. pdfcpu のインストール
+
+```bash
+cd external_tools/external_tools/image_tools/pdfcpu
+
+# 最新版をダウンロード (v0.11.1)
+curl -sL "https://github.com/pdfcpu/pdfcpu/releases/download/v0.11.1/pdfcpu_0.11.1_Linux_x86_64.tar.xz" -o pdfcpu.tar.xz
+tar xJf pdfcpu.tar.xz
+mv pdfcpu_*/pdfcpu .
+rm -rf pdfcpu_* pdfcpu.tar.xz
+chmod +x pdfcpu
+
+# 確認
+./pdfcpu version
+```
+
+## 5. Tesseract OCR データのコピー
+
+```bash
+cp /usr/share/tesseract-ocr/4.00/tessdata/{eng,jpn,jpn_vert,osd}.traineddata \
+   external_tools/external_tools/image_tools/TesseractOCR_Data/
+```
+
+## 6. RealEsrgan のセットアップ (CUDA 対応)
+
+```bash
+cd external_tools/external_tools/image_tools/RealEsrgan
+mkdir -p RealEsrgan_Repo
+cd RealEsrgan_Repo
+
+# リポジトリをクローン
+git clone https://github.com/xinntao/Real-ESRGAN.git .
+
+# シンボリックリンク作成 (コードが Real-ESRGAN/ サブディレクトリを期待するため)
+ln -s . Real-ESRGAN
+
+# Python 仮想環境を作成
+python3 -m venv venv
+source venv/bin/activate
+
+# pip をアップグレード
+pip install --upgrade pip
+
+# PyTorch + CUDA 11.8 をインストール
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+
+# RealEsrgan 依存関係をインストール (realesrgan は後でローカルからインストール)
+pip install basicsr facexlib gfpgan opencv-python numpy
+
+# Real-ESRGAN をローカルからインストール
+pip install -e .
+
+# basicsr の torchvision 互換性パッチ (新しい torchvision では functional_tensor が削除されている)
+sed -i 's/from torchvision.transforms.functional_tensor import rgb_to_grayscale/from torchvision.transforms.functional import rgb_to_grayscale/' \
+    venv/lib/python*/site-packages/basicsr/data/degradations.py
+
+# CUDA 動作確認
+python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
+```
+
+## 7. プロジェクトのビルド
+
+```bash
+cd /path/to/DN_SuperBook_PDF_Converter
+
+# ビルド
+dotnet build SuperBookToolsApp/SuperBookToolsApp.csproj
+
+# OpenCvSharp ネイティブライブラリのシンボリックリンクを作成
+# (Ubuntu 版ランタイムが ubuntu.22.04-x64 にあるが、.NET は linux-x64 を探すため)
+cd SuperBookToolsApp/bin/Debug/net8.0/runtimes/linux-x64/native/
+ln -s ../../ubuntu.22.04-x64/native/libOpenCvSharpExtern.so libOpenCvSharpExtern.so
+cd -
+
+# 実行
+dotnet run --project SuperBookToolsApp/SuperBookToolsApp.csproj
+```
+
+## 8. PDF 変換の実行
+
+アプリケーション起動後、プロンプトで以下のコマンドを実行:
+
+```
+SuperBookTools> ConvertPdf /path/to/source/pdfs /dst:/path/to/output
+```
+
+## トラブルシューティング
+
+### ImageMagick で PDF エラーが出る場合
+
+```bash
+# ポリシーファイルを確認
+cat /etc/ImageMagick-6/policy.xml | grep PDF
+
+# 制限が残っている場合は手動で編集
+sudo nano /etc/ImageMagick-6/policy.xml
+# <policy domain="coder" rights="none" pattern="PDF" /> を
+# <policy domain="coder" rights="read|write" pattern="PDF" /> に変更
+```
+
+### ImageMagick で "cache resources exhausted" エラーが出る場合
+
+大きな PDF を処理するときにメモリ/ディスク制限に達した場合:
+
+```bash
+# 現在の制限を確認
+cat /etc/ImageMagick-6/policy.xml | grep -E "(memory|disk)"
+
+# メモリとディスク制限を拡大
+sudo sed -i 's/name="memory" value="256MiB"/name="memory" value="4GiB"/' /etc/ImageMagick-6/policy.xml
+sudo sed -i 's/name="disk" value="1GiB"/name="disk" value="16GiB"/' /etc/ImageMagick-6/policy.xml
+```
+
+### CUDA が認識されない場合
+
+```bash
+# NVIDIA ドライバの確認
+nvidia-smi
+
+# WSL2 で CUDA を使う場合、Windows 側に NVIDIA ドライバが必要
+# WSL2 内には CUDA ツールキットのみインストール
+```
+
+### OpenCvSharp でエラーが出る場合
+
+```bash
+# GTK2 依存ライブラリのインストール (libgtk-x11-2.0.so.0 が見つからない場合)
+sudo apt-get install -y libgtk2.0-0
+
+# libOpenCvSharpExtern.so が見つからない場合
+cd SuperBookToolsApp/bin/Debug/net8.0/runtimes/linux-x64/native/
+ln -s ../../ubuntu.22.04-x64/native/libOpenCvSharpExtern.so libOpenCvSharpExtern.so
+
+# その他の依存ライブラリ
+sudo apt-get install -y libgdiplus libc6-dev
+```
+
+### basicsr で torchvision エラーが出る場合
+
+```bash
+# "No module named 'torchvision.transforms.functional_tensor'" エラーの対処
+sed -i 's/from torchvision.transforms.functional_tensor import rgb_to_grayscale/from torchvision.transforms.functional import rgb_to_grayscale/' \
+    external_tools/external_tools/image_tools/RealEsrgan/RealEsrgan_Repo/venv/lib/python*/site-packages/basicsr/data/degradations.py
+```
+
+## 外部ツールのパス構成
+
+```
+external_tools/
+└── external_tools/
+    └── image_tools/
+        ├── pdfcpu/
+        │   └── pdfcpu          # Linux バイナリ
+        ├── RealEsrgan/
+        │   └── RealEsrgan_Repo/
+        │       ├── venv/       # Python 仮想環境
+        │       └── ...         # RealEsrgan ソースコード
+        └── TesseractOCR_Data/
+            ├── eng.traineddata
+            ├── jpn.traineddata
+            └── jpn_vert.traineddata
+```
+
+## 注意事項
+
+- RealEsrgan は CUDA なしだと非常に遅くなります (CPU フォールバックは実用的でない)
+- メモリ使用量が大きい (数 GB 〜 数十 GB の可能性)
+- Windows でも同じソリューションでビルド可能 (OS 判定で自動分岐)

--- a/SuperBookToolsApp/SuperBookToolsApp.csproj
+++ b/SuperBookToolsApp/SuperBookToolsApp.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
     <PackageId>SuperBookToolsApp</PackageId>
     <Authors>dnobori</Authors>
     <ServerGarbageCollection>false</ServerGarbageCollection>
@@ -69,9 +69,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.6" />
-    <PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
-    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
-    <PackageReference Include="OpenCvSharp4.Extensions" Version="4.11.0.20250507" />
+    <PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20240616" Condition="'$(RuntimeIdentifier)' == 'win-x64' Or ('$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('Windows')))" />
+    <PackageReference Include="OpenCvSharp4_.runtime.ubuntu.20.04-x64" Version="4.10.0.20240616" Condition="'$(RuntimeIdentifier)' == 'linux-x64' Or ('$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('Linux')))" />
+    <PackageReference Include="OpenCvSharp4.Extensions" Version="4.10.0.20240616" />
     <PackageReference Include="Tesseract" Version="5.2.0" />
   </ItemGroup>
 

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+# DN_SuperBook_PDF_Converter Linux/WSL2 セットアップスクリプト
+# CUDA (RTX 3090等) 対応版
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+EXTERNAL_TOOLS_DIR="$PROJECT_ROOT/external_tools/external_tools/image_tools"
+
+echo "========================================"
+echo "DN_SuperBook_PDF_Converter Linux Setup"
+echo "========================================"
+
+# 1. システムパッケージのインストール
+echo ""
+echo "[1/5] Installing system packages..."
+sudo apt-get update
+sudo apt-get install -y \
+    imagemagick \
+    ghostscript \
+    libimage-exiftool-perl \
+    qpdf \
+    python3 \
+    python3-pip \
+    python3-venv \
+    libtesseract-dev \
+    tesseract-ocr \
+    tesseract-ocr-jpn \
+    tesseract-ocr-jpn-vert \
+    wget \
+    unzip \
+    libgtk2.0-0
+
+# 2. ImageMagick PDF ポリシー設定
+# デフォルトでは PDF の読み書きが制限されているので解除
+echo ""
+echo "[2/5] Configuring ImageMagick PDF policy..."
+POLICY_FILE="/etc/ImageMagick-6/policy.xml"
+if [ -f "$POLICY_FILE" ]; then
+    # PDF 制限を緩和 (コメントアウトまたは削除)
+    sudo sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' "$POLICY_FILE"
+    echo "ImageMagick PDF policy updated: $POLICY_FILE"
+else
+    echo "Warning: ImageMagick policy file not found at $POLICY_FILE"
+    echo "Trying ImageMagick-7 location..."
+    POLICY_FILE="/etc/ImageMagick-7/policy.xml"
+    if [ -f "$POLICY_FILE" ]; then
+        sudo sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' "$POLICY_FILE"
+        echo "ImageMagick PDF policy updated: $POLICY_FILE"
+    fi
+fi
+
+# 3. pdfcpu Linux バイナリのダウンロード
+echo ""
+echo "[3/5] Setting up pdfcpu..."
+PDFCPU_DIR="$EXTERNAL_TOOLS_DIR/pdfcpu"
+mkdir -p "$PDFCPU_DIR"
+
+if [ ! -f "$PDFCPU_DIR/pdfcpu" ]; then
+    echo "Downloading pdfcpu for Linux..."
+    PDFCPU_VERSION="0.11.1"
+    curl -sL "https://github.com/pdfcpu/pdfcpu/releases/download/v${PDFCPU_VERSION}/pdfcpu_${PDFCPU_VERSION}_Linux_x86_64.tar.xz" -o /tmp/pdfcpu.tar.xz
+    tar -xJf /tmp/pdfcpu.tar.xz -C /tmp
+    mv /tmp/pdfcpu_${PDFCPU_VERSION}_Linux_x86_64/pdfcpu "$PDFCPU_DIR/pdfcpu"
+    chmod +x "$PDFCPU_DIR/pdfcpu"
+    rm -rf /tmp/pdfcpu.tar.xz /tmp/pdfcpu_${PDFCPU_VERSION}_Linux_x86_64
+    echo "pdfcpu installed to: $PDFCPU_DIR/pdfcpu"
+else
+    echo "pdfcpu already exists, skipping download"
+fi
+
+# 4. RealEsrgan Python 仮想環境のセットアップ
+echo ""
+echo "[4/5] Setting up RealEsrgan venv with CUDA support..."
+REALESRGAN_DIR="$EXTERNAL_TOOLS_DIR/RealEsrgan/RealEsrgan_Repo"
+
+if [ -d "$REALESRGAN_DIR" ]; then
+    cd "$REALESRGAN_DIR"
+
+    # Real-ESRGAN サブディレクトリへのシンボリックリンク作成
+    # (コードが Real-ESRGAN/inference_realesrgan.py を期待するため)
+    if [ ! -e "Real-ESRGAN" ]; then
+        echo "Creating Real-ESRGAN symlink..."
+        ln -s . Real-ESRGAN
+    fi
+
+    if [ ! -d "venv" ]; then
+        echo "Creating Python venv..."
+        python3 -m venv venv
+
+        echo "Activating venv and installing packages..."
+        source venv/bin/activate
+
+        pip install --upgrade pip
+
+        # PyTorch with CUDA support (CUDA 11.8)
+        # RTX 3090 に対応
+        echo "Installing PyTorch with CUDA support..."
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+
+        # RealEsrgan requirements
+        pip install basicsr facexlib gfpgan opencv-python numpy
+
+        # Real-ESRGAN をローカルからインストール (realesrgan パッケージ)
+        echo "Installing Real-ESRGAN from local source..."
+        pip install -e .
+
+        # basicsr の torchvision 互換性パッチ
+        # (新しい torchvision では functional_tensor が削除されているため)
+        echo "Patching basicsr for torchvision compatibility..."
+        DEGRADATIONS_FILE="$REALESRGAN_DIR/venv/lib/python*/site-packages/basicsr/data/degradations.py"
+        for f in $DEGRADATIONS_FILE; do
+            if [ -f "$f" ]; then
+                sed -i 's/from torchvision.transforms.functional_tensor import rgb_to_grayscale/from torchvision.transforms.functional import rgb_to_grayscale/' "$f"
+                echo "Patched: $f"
+            fi
+        done
+
+        deactivate
+        echo "RealEsrgan venv setup complete"
+    else
+        echo "RealEsrgan venv already exists, skipping"
+    fi
+else
+    echo "Warning: RealEsrgan directory not found at $REALESRGAN_DIR"
+    echo "Please clone the RealEsrgan repository manually or ensure external_tools is properly set up"
+fi
+
+# 5. Tesseract OCR データの確認
+echo ""
+echo "[5/5] Checking Tesseract OCR data..."
+TESSDATA_DIR="$EXTERNAL_TOOLS_DIR/TesseractOCR_Data"
+mkdir -p "$TESSDATA_DIR"
+
+# システムの tessdata をシンボリックリンクまたはコピー
+if [ ! -f "$TESSDATA_DIR/jpn.traineddata" ]; then
+    echo "Setting up Tesseract data..."
+    SYSTEM_TESSDATA="/usr/share/tesseract-ocr/4.00/tessdata"
+    if [ -d "$SYSTEM_TESSDATA" ]; then
+        cp "$SYSTEM_TESSDATA/jpn.traineddata" "$TESSDATA_DIR/" 2>/dev/null || true
+        cp "$SYSTEM_TESSDATA/jpn_vert.traineddata" "$TESSDATA_DIR/" 2>/dev/null || true
+        cp "$SYSTEM_TESSDATA/eng.traineddata" "$TESSDATA_DIR/" 2>/dev/null || true
+        echo "Tesseract data copied from system"
+    else
+        # 5.x 版
+        SYSTEM_TESSDATA="/usr/share/tesseract-ocr/5/tessdata"
+        if [ -d "$SYSTEM_TESSDATA" ]; then
+            cp "$SYSTEM_TESSDATA/jpn.traineddata" "$TESSDATA_DIR/" 2>/dev/null || true
+            cp "$SYSTEM_TESSDATA/jpn_vert.traineddata" "$TESSDATA_DIR/" 2>/dev/null || true
+            cp "$SYSTEM_TESSDATA/eng.traineddata" "$TESSDATA_DIR/" 2>/dev/null || true
+            echo "Tesseract data copied from system (5.x)"
+        else
+            echo "Warning: System tessdata not found, please copy traineddata files manually"
+        fi
+    fi
+else
+    echo "Tesseract data already exists"
+fi
+
+# 6. OpenCvSharp ネイティブライブラリのシンボリックリンク作成
+# (ビルド後に実行が必要)
+echo ""
+echo "[6/6] Note about OpenCvSharp native library..."
+echo "After building, you need to create a symlink for OpenCvSharp:"
+echo ""
+echo "  cd SuperBookToolsApp/bin/Debug/net8.0/runtimes/linux-x64/native/"
+echo "  ln -s ../../ubuntu.22.04-x64/native/libOpenCvSharpExtern.so libOpenCvSharpExtern.so"
+echo ""
+
+# 完了
+echo ""
+echo "========================================"
+echo "Setup complete!"
+echo "========================================"
+echo ""
+echo "Next steps:"
+echo "1. Build the project:"
+echo "   dotnet build SuperBookToolsApp/SuperBookToolsApp.csproj"
+echo ""
+echo "2. Create OpenCvSharp symlink (after first build):"
+echo "   cd SuperBookToolsApp/bin/Debug/net8.0/runtimes/linux-x64/native/"
+echo "   ln -s ../../ubuntu.22.04-x64/native/libOpenCvSharpExtern.so libOpenCvSharpExtern.so"
+echo "   cd -"
+echo ""
+echo "3. Run the application:"
+echo "   dotnet run --project SuperBookToolsApp/SuperBookToolsApp.csproj"
+echo ""
+echo "4. At the prompt, use:"
+echo "   ConvertPdf <srcDir> /dst:<dstDir>"
+echo ""


### PR DESCRIPTION
主な変更点:
- OS判定による条件分岐 (Windows/Linux)
  - シェルコマンド (cmd.exe vs /bin/bash)
  - Python venv パス (Scripts vs bin)
  - ImageMagick コマンド (magick vs convert)
  - 外部ツールパス
- .NET 8.0 へのアップグレード
- OpenCvSharp4 の Linux ランタイム対応
- IPNetwork の曖昧参照解決

新規ファイル:
- INSTALL.md: WSL2/Linux インストールガイド
- CLAUDE.md: Claude Code 用プロジェクト説明
- scripts/setup_linux.sh: Linux 環境セットアップスクリプト

動作確認済み環境:
- Ubuntu 22.04 (WSL2)
- NVIDIA RTX 3090 (CUDA 11.8)
- RealESRGAN による PDF 高品質化